### PR TITLE
Anonymous users can be confirmed

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -211,7 +211,7 @@ exports.setupUserToPublic = function (user, dbname, hoodie, callback) {
 // when a user doc changes, check if we need to setup replication for it
 exports.handleChange = function (doc, dbname, hoodie, callback) {
 
-  if (_.contains(doc.roles, 'confirmed') && doc.database) {
+  if (_.contains(doc.roles, 'confirmed') && doc.type != 'user_anonymous' && doc.database) {
 
     if (!doc.globalShares) {
       exports.setupUserToPublic(doc, dbname, hoodie, function (err) {


### PR DESCRIPTION
I have an anonymous user that is confirmed, not sure how with a vanilla install, which breaks the plugin and does not let the server start. 

Good to have this check I guess. 
